### PR TITLE
Fix plus button format

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -66,7 +66,7 @@ main {
 
 .user-input-form {
   background-color: #587A8A;
-  border-right: 2px solid #1F1F3D;
+  border-right: 2px solid #41687A;
   height: 100vh;
   width: 33%;
 }
@@ -98,6 +98,23 @@ main {
   width: 66%;
 }
 
+#add-task-button {
+  font-size: 4em !important;
+  font-weight: 100;
+  height: 56px;
+  line-height: 50px;
+  margin-bottom: 50px;
+  margin-right: 4.5% !important;
+  margin-top: -105px !important;
+  text-align: center;
+  vertical-align: middle;
+  width: 56px !important;
+}
+
+/* #add-task-button:focus {
+  outline: none;
+} */
+
 .form-button {
   background-color: #1F1F3D;
   border: none;
@@ -114,7 +131,7 @@ main {
 }
 
 .urgent-filter {
-  border-top: 2px solid #1F1F3D;
+  border-top: 2px solid #41687A;
   margin-top: 40px;
 }
 


### PR DESCRIPTION
- Fixed formatting for plus button.

Notes: 

- The plus button is laid over top of the input. When we add padding to this specific input box we should add a padding-right of the width of the plus button plus whatever we want the actual padding to be to avoid text going under the button. 

- There is a weird problem where the outline of the button extends above and below the button height when the button is clicked. This may be due to line height. We can remove the outline completely and may be able to remove it and add a border on click. 